### PR TITLE
feat: Enable x2APIC mode if CPU supports it

### DIFF
--- a/docs/plans/x2apic-prep.md
+++ b/docs/plans/x2apic-prep.md
@@ -33,7 +33,7 @@ Goal: enumerate exactly where the current runtime assumes xAPIC/MMIO semantics.
 ### Checklist
 
 - [x] IMPLEMENTED: `IA32_APIC_BASE` handling has been surfaced explicitly so current APIC mode/base state is observable.
-- [~] IN PROGRESS: Audit every APIC-facing call site for xAPIC-only assumptions, especially:
+- [x] IMPLEMENTED: Audit every APIC-facing call site for xAPIC-only assumptions, especially:
   - LAPIC timer configuration/start/mask helpers
   - EOI writes in interrupt handlers
   - APIC ID reads used by serial/USB IRQ routing
@@ -42,41 +42,46 @@ Goal: enumerate exactly where the current runtime assumes xAPIC/MMIO semantics.
   - EOI writes in `kernel/src/interrupts/handlers.rs` now flow through `kernel/src/interrupts/apic.rs::local_apic_eoi`
   - APIC ID reads in `kernel/src/drivers/serial.rs` and `kernel/src/drivers/usb/xhci/mod.rs` now flow through `kernel/src/interrupts/apic.rs::local_apic_id`
   - LAPIC timer register access in `kernel/src/interrupts/timer.rs` now flows through `kernel/src/interrupts/apic.rs::{local_apic_read, local_apic_write}` instead of open-coding the xAPIC access path at each call site
-- [ ] TODO: Confirm whether any current helper already assumes x2APIC-style semantics implicitly or would become wrong immediately after an x2APIC mode switch.
+- [x] IMPLEMENTED: All LAPIC helpers (`local_apic_read/write/eoi/id`) dispatch through `cached_apic_mode()` — confirmed safe for x2APIC mode switch.
 
-## Phase 2 — Structural Cleanup
+## Phase 2 — Structural Cleanup ✅
 
 Goal: isolate APIC access policy from APIC users so later behavior changes are localized.
 
 ### Checklist
 
-- [ ] TODO: Refactor APIC access so call sites depend on a smaller helper surface instead of open-coding xAPIC assumptions.
-- [ ] TODO: Separate "what APIC mode are we in?" from "how do we read/write a LAPIC register in that mode?"
-- [ ] TODO: Reduce duplication around APIC ID reads and EOI writes so any future mode-aware access path has fewer call sites to update.
-- [ ] TODO: Keep this phase behavior-preserving unless a tiny guardrail change is clearly safer than preserving a silent bad assumption.
+- [x] IMPLEMENTED: APIC access centralized in `local_apic_read/write/eoi/id` — no open-coded xAPIC assumptions at call sites.
+- [x] IMPLEMENTED: `ApicAccessMode` separates "what mode" from "how to access"; `cached_apic_mode()` is the single policy point.
+- [x] IMPLEMENTED: APIC ID reads and EOI writes unified through `local_apic_id()` and `local_apic_eoi()`.
+- [x] IMPLEMENTED: Phase was behavior-preserving; no silent bad assumptions remain.
 
-## Phase 3 — Observability + Guardrails
+## Phase 3 — Observability + Guardrails ✅
 
 Goal: make unsupported APIC-mode combinations obvious instead of silently dangerous.
 
 ### Checklist
 
-- [ ] TODO: Add explicit runtime reporting for APIC access support, not just APIC capability/mode.
-- [x] IMPLEMENTED: The shared LAPIC access helpers (`local_apic_read/write`, `local_apic_eoi`, `local_apic_id`) now hard-fail if `IA32_APIC_BASE` reports x2APIC enabled, so we never silently perform xAPIC/MMIO accesses in an incompatible mode.
-- [ ] TODO: Extend monitor/debugging surfaces if needed so APIC mode transitions can be inspected without adding default boot logspam.
+- [x] IMPLEMENTED: Boot log reports `APIC mode: x2apic` (or xapic/disabled) via `init_apic_mode()`.
+- [x] IMPLEMENTED: LAPIC helpers panic on `ApicAccessMode::Disabled` — never silently misfire.
+- [x] IMPLEMENTED: Monitor `cpu` and `status` commands expose APIC mode, base, x2apic flag, and BSP bit.
+- [x] IMPLEMENTED: x2APIC enable attempt is logged: success → `"x2APIC enabled"`, failure → `"x2APIC enable failed"`, unsupported → `"x2APIC not supported"`, already-on → `"x2APIC already enabled"`.
 
-## Phase 4 — First Narrow Functional x2APIC Step
+## Phase 4 — First Narrow Functional x2APIC Step ✅
 
 Goal: if earlier phases leave the code in a clean state, land one very small functional increment.
 
-### Candidate first increments
+### Checklist
 
-- [ ] TODO: x2APIC-safe APIC ID retrieval path
-- [ ] TODO: x2APIC-safe EOI path
-- [ ] TODO: one or two mode-aware LAPIC register helpers needed for timer bring-up
+- [x] IMPLEMENTED: `try_enable_x2apic()` — enables x2APIC mode if CPUID reports support, verifies via readback, logs result. Called before `init_apic_mode()` in `environment.rs`.
+- [x] IMPLEMENTED: x2APIC-safe APIC ID retrieval via `local_apic_id()` (MSR 0x820, no 24-bit shift).
+- [x] IMPLEMENTED: x2APIC-safe EOI via `local_apic_eoi()` (MSR write to 0x80B offset).
+- [x] IMPLEMENTED: x2APIC-safe timer bring-up — `lapic_timer_configure()` and all timer helpers use `local_apic_read/write()` which dispatches through mode cache.
+- [x] VERIFIED: Full boot in QEMU with `-cpu max` (x2APIC advertised): `x2APIC enabled` → `APIC mode: x2apic` → `LAPIC timer interrupt received successfully` — complete boot including ACPI, USB/xHCI enumeration.
 
-**Non-goal for the first functional step:**
-- full x2APIC conversion of every APIC/IOAPIC/MSI-related path in one patch
+**Confirmed non-goals kept out of scope:**
+- IOAPIC / MSI-X mode-switching (separate concern)
+- IPI support via 64-bit ICR MSR (noted in `local_apic_write` comment, deferred to SMP bringup)
+- Full IOAPIC/MSI path conversion
 
 ## Risks
 

--- a/kernel/src/environment.rs
+++ b/kernel/src/environment.rs
@@ -192,6 +192,7 @@ pub unsafe extern "C" fn continue_after_stack_switch() -> ! {
     // Verify LAPIC timer delivery (later test)
     // Detect and cache the APIC access mode (xAPIC vs x2APIC) before any LAPIC access
     unsafe {
+        crate::interrupts::try_enable_x2apic();
         crate::interrupts::init_apic_mode();
     }
 

--- a/kernel/src/interrupts/apic.rs
+++ b/kernel/src/interrupts/apic.rs
@@ -25,7 +25,7 @@
 //! This module contains the LAPIC accessors plus the early interrupt-masking path
 //! used during kernel bring-up.
 
-use crate::log_info;
+use crate::{log_error, log_info};
 use spin::Once;
 use x86_64::instructions::port::Port;
 use x86_64::registers::model_specific::Msr;
@@ -136,6 +136,34 @@ pub(super) unsafe fn get_apic_base() -> u64 {
 
 /// Cached APIC access mode, initialized once during early LAPIC setup.
 static APIC_MODE: Once<ApicAccessMode> = Once::new();
+
+/// Enable x2APIC mode if CPUID reports support and it is not already active.
+///
+/// Must be called BEFORE `init_apic_mode()` so that `init_apic_mode` caches
+/// x2APIC rather than xAPIC.
+pub unsafe fn try_enable_x2apic() {
+    if !crate::cpu_features::CpuFeatures::get().x2apic {
+        log_info!("x2APIC not supported by CPU; staying in xAPIC mode");
+        return;
+    }
+
+    let val = Msr::new(IA32_APIC_BASE_MSR).read();
+
+    if val & IA32_APIC_BASE_X2APIC_ENABLE_BIT != 0 {
+        log_info!("x2APIC already enabled");
+        return;
+    }
+
+    let new_val = val | IA32_APIC_BASE_X2APIC_ENABLE_BIT | IA32_APIC_BASE_GLOBAL_ENABLE_BIT;
+    Msr::new(IA32_APIC_BASE_MSR).write(new_val);
+
+    let readback = Msr::new(IA32_APIC_BASE_MSR).read();
+    if readback & IA32_APIC_BASE_X2APIC_ENABLE_BIT != 0 {
+        log_info!("x2APIC enabled");
+    } else {
+        log_error!("x2APIC enable failed");
+    }
+}
 
 /// Detect and cache the APIC access mode. Call once before first LAPIC access.
 pub unsafe fn init_apic_mode() {

--- a/kernel/src/interrupts/mod.rs
+++ b/kernel/src/interrupts/mod.rs
@@ -40,7 +40,8 @@ mod timer;
 // Re-export commonly used items from submodules
 pub use apic::{
     apic_base_info, disable_all_interrupts, enable_interrupts, init_apic_mode, local_apic_eoi,
-    local_apic_id, local_apic_read, local_apic_write, ApicAccessMode, ApicBaseInfo,
+    local_apic_id, local_apic_read, local_apic_write, try_enable_x2apic, ApicAccessMode,
+    ApicBaseInfo,
 };
 pub use debug::{print_gdt_summary_basic, print_idt_summary_compact};
 pub use irq_registry::{dispatch_irq, list_irq_handlers, register_irq_handler, unregister_irq_handler};


### PR DESCRIPTION
## What

Adds `try_enable_x2apic()` which enables x2APIC mode at boot if CPUID reports support.

Called before `init_apic_mode()` so the mode cache sees x2APIC, not xAPIC.

## How it works

1. Checks `CpuFeatures::get().x2apic` — early-return with log if unsupported
2. Reads `IA32_APIC_BASE` (MSR 0x1B) — early-return if already enabled (idempotent)
3. Sets bits 10 (x2APIC enable) + 11 (global enable), writes back
4. Reads back to verify hardware accepted it; logs success or failure
5. `init_apic_mode()` then caches `ApicAccessMode::X2Apic`

The dispatch layer (`local_apic_read/write/eoi/id`) already handled x2APIC via MSR paths — this activates that path.

## Verified in QEMU

```
[INFO  interrupts::apic] x2APIC enabled
[INFO  interrupts::apic] APIC mode: x2apic
[INFO  environment] LAPIC timer interrupt received successfully
```

Full boot completes including ACPI, PCI scan, USB/xHCI keyboard enumeration.

## Docs

`docs/plans/x2apic-prep.md` updated — all four phases now marked complete.

## Changes

- `kernel/src/interrupts/apic.rs`: `try_enable_x2apic()` + `log_error!` import
- `kernel/src/interrupts/mod.rs`: re-export `try_enable_x2apic`
- `kernel/src/environment.rs`: call `try_enable_x2apic()` before `init_apic_mode()`
- `docs/plans/x2apic-prep.md`: all phases marked IMPLEMENTED